### PR TITLE
update next.js to v11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 - [Next.js](https://nextjs.org/)
 
+  - [Next.js v11.1](https://nextjs.org/blog/next-11-1)
+
   - [Next.js v11](https://nextjs.org/blog/next-11)
 
   - [Next.js v10.1](https://nextjs.org/blog/next-10-1)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.14.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
@@ -25,6 +30,14 @@
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/runtime": {
@@ -46,12 +59,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -105,9 +117,9 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.3.tgz",
-      "integrity": "sha512-RlrGyZ603hE/eRTZtTltocRm50HHmrmL3kGOP0SQ9MasazlW1mt/fkv4C5P/6rnpFXjwld/POFX1C8tMZE3ldg==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -151,10 +163,15 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "@napi-rs/triples": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
+      "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
+    },
     "@next/env": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.0.1.tgz",
-      "integrity": "sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.0.tgz",
+      "integrity": "sha512-zPJkMFRenSf7BLlVee8987G0qQXAhxy7k+Lb/5hLAGkPVHAHm+oFFeL+2ipbI2KTEFlazdmGY0M+AlLQn7pWaw=="
     },
     "@next/eslint-plugin-next": {
       "version": "11.0.1",
@@ -163,14 +180,14 @@
       "dev": true
     },
     "@next/polyfill-module": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.0.1.tgz",
-      "integrity": "sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.0.tgz",
+      "integrity": "sha512-64EgW8SzJRQls2yJ5DkuljRxgE24o2kYtX/ghTkPUJYsfidHMWzQGwg26IgRbb/uHqTd1G0W5UkKag+Nt8TWaQ=="
     },
     "@next/react-dev-overlay": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.0.1.tgz",
-      "integrity": "sha512-lvUjMVpLsgzADs9Q8wtC5LNqvfdN+M0BDMSrqr04EDWAyyX0vURHC9hkvLbyEYWyh+WW32pwjKBXdkMnJhoqMg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.0.tgz",
+      "integrity": "sha512-h+ry0sTk1W3mJw+TwEf91aqLbBJ5oqAsxfx+QryqEItNtfW6zLSSjxkyTYTqX8DkgSssQQutQfATkzBVgOR+qQ==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -231,9 +248,17 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.0.1.tgz",
-      "integrity": "sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.0.tgz",
+      "integrity": "sha512-g5DtFTpLTGa36iy9DuZawtJeitI11gysFGKPQQqy+mNbSFazguArcJ10gAYFlbqpIi4boUamWNI5mAoSPx3kog=="
+    },
+    "@node-rs/helper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
+      "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
+      "requires": {
+        "@napi-rs/triples": "^1.0.3"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -276,8 +301,7 @@
     "@types/node": {
       "version": "14.17.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
-      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
-      "dev": true
+      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -828,11 +852,6 @@
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
     },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1061,9 +1080,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001248",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1543,19 +1562,19 @@
       "dev": true
     },
     "cssnano-preset-simple": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-2.0.0.tgz",
-      "integrity": "sha512-HkufSLkaBJbKBFx/7aj5HmCK9Ni/JedRQm0mT2qBzMG/dEuJOLnMt2lK6K1rwOOyV4j9aSY+knbW9WoS7BYpzg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-3.0.0.tgz",
+      "integrity": "sha512-vxQPeoMRqUT3c/9f0vWeVa2nKQIHFpogtoBvFdW4GQ3IvEJ6uauCP6p3Y5zQDLFcI7/+40FTgX12o7XUL0Ko+w==",
       "requires": {
         "caniuse-lite": "^1.0.30001202"
       }
     },
     "cssnano-simple": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-2.0.0.tgz",
-      "integrity": "sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-3.0.0.tgz",
+      "integrity": "sha512-oU3ueli5Dtwgh0DyeohcIEE00QVfbPR3HzyXdAl89SfnQG3y0/qcpfLVW+jPIh3/rgMZGwuW96rejZGaYE9eUg==",
       "requires": {
-        "cssnano-preset-simple": "^2.0.0"
+        "cssnano-preset-simple": "^3.0.0"
       }
     },
     "csstype": {
@@ -1687,9 +1706,9 @@
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.795",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.795.tgz",
-      "integrity": "sha512-4TPxrLf9Fzsi4rVgTlDm+ubxoXm3/TN67/LGHx/a4UkVubKILa6L26O6eTnHewixG/knzU9L3lLmfL39eElwlQ=="
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -2372,7 +2391,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -2748,6 +2768,14 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
     "hash-base": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
@@ -2954,11 +2982,12 @@
       }
     },
     "is-arguments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -3034,9 +3063,12 @@
       "dev": true
     },
     "is-generator-function": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
-      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.1",
@@ -3111,15 +3143,15 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
-      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.7.tgz",
+      "integrity": "sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==",
       "requires": {
-        "available-typed-arrays": "^1.0.2",
+        "available-typed-arrays": "^1.0.4",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.0-next.2",
+        "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
-        "has-symbols": "^1.0.1"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-unicode-supported": {
@@ -3158,11 +3190,6 @@
         "supports-color": "^8.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "16.4.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.11.tgz",
-          "integrity": "sha512-nWSFUbuNiPKJEe1IViuodSI+9cM+vpM8SWF/O6dJK7wmGRNq55U7XavJHrlRrPkSMuUZUFzg1xaZ1B+ZZCrRWw=="
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3423,7 +3450,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -3730,16 +3758,17 @@
       "dev": true
     },
     "next": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.0.1.tgz",
-      "integrity": "sha512-yR7be7asNbvpVNpi6xxEg28wZ7Gqmj1nOt0sABH9qORmF3+pms2KZ7Cng33oK5nqPIzEEFJD0pp2PCe3/ueMIg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.1.0.tgz",
+      "integrity": "sha512-GHBk/c7Wyr6YbFRFZF37I0X7HKzkHHI8pur/loyXo5AIE8wdkbGPGO0ds3vNAO6f8AxZAKGCRYtAzoGlVLoifA==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.0.1",
-        "@next/polyfill-module": "11.0.1",
-        "@next/react-dev-overlay": "11.0.1",
-        "@next/react-refresh-utils": "11.0.1",
+        "@next/env": "11.1.0",
+        "@next/polyfill-module": "11.1.0",
+        "@next/react-dev-overlay": "11.1.0",
+        "@next/react-refresh-utils": "11.1.0",
+        "@node-rs/helper": "1.2.1",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
@@ -3750,7 +3779,7 @@
         "chokidar": "3.5.1",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "cssnano-simple": "2.0.0",
+        "cssnano-simple": "3.0.0",
         "domain-browser": "4.19.0",
         "encoding": "0.1.13",
         "etag": "1.8.1",
@@ -3767,9 +3796,8 @@
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "8.2.13",
+        "postcss": "8.2.15",
         "process": "0.11.10",
-        "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
         "react-is": "17.0.2",
@@ -3777,7 +3805,7 @@
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
         "string_decoder": "1.3.0",
-        "styled-jsx": "3.3.2",
+        "styled-jsx": "4.0.0",
         "timers-browserify": "2.0.12",
         "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
@@ -3795,12 +3823,12 @@
           }
         },
         "postcss": {
-          "version": "8.2.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
-          "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
+          "version": "8.2.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+          "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
           "requires": {
             "colorette": "^1.2.2",
-            "nanoid": "^3.1.22",
+            "nanoid": "^3.1.23",
             "source-map": "^0.6.1"
           }
         },
@@ -3996,9 +4024,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4588,6 +4616,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4597,7 +4626,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },
@@ -5477,12 +5507,12 @@
       }
     },
     "styled-jsx": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.3.2.tgz",
-      "integrity": "sha512-daAkGd5mqhbBhLd6jYAjYBa9LpxYCzsgo/f6qzPdFxVB8yoGbhxvzQgkC0pfmCVvW3JuAEBn0UzFLBfkHVZG1g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.0.tgz",
+      "integrity": "sha512-2USeoWMoJ/Lx5s2y1PxuvLy/cz2Yrr8cTySV3ILHU1Vmaw1bnV7suKdblLPjnyhMD+qzN7B1SWyh4UZTARn/WA==",
       "requires": {
-        "@babel/types": "7.8.3",
-        "babel-plugin-syntax-jsx": "6.18.0",
+        "@babel/plugin-syntax-jsx": "7.14.5",
+        "@babel/types": "7.15.0",
         "convert-source-map": "1.7.0",
         "loader-utils": "1.2.3",
         "source-map": "0.7.3",
@@ -6124,17 +6154,16 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
-      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.6.tgz",
+      "integrity": "sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==",
       "requires": {
-        "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
+        "available-typed-arrays": "^1.0.4",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.1",
-        "is-typed-array": "^1.1.3"
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.6"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clsx": "1.1.1",
     "i18next": "20.4.0",
     "i18next-browser-languagedetector": "6.1.2",
-    "next": "^11.0.1",
+    "next": "^11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-i18next": "11.11.4"


### PR DESCRIPTION
- [next.js v11.1 release notes](https://github.com/vercel/next.js/releases/tag/v11.1.0)

- [next.js v11.1 blog post](https://nextjs.org/blog/next-11-1)

- [Next.js upgrating guide](https://nextjs.org/docs/upgrading)